### PR TITLE
WWDR Certificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Typical usage often looks like this::
     passfile.addFile('images/icon.png')
     passfile.addFile('images/icon@2x.png')
     passfile.addFile('images/logo.png')
-    passfile.create('certificate.pem', 'key.pem', '123456') # Create and output the Passbook file (.pkpass) 
+    passfile.create('certificate.pem', 'key.pem', 'wwdr.pem', '123456') # Create and output the Passbook file (.pkpass) 
 
 
 Creating Pass Certificates
@@ -43,3 +43,10 @@ TO-DO:
 2. Second. 
 
 Developed by `devartis <http://www.devartis.com>`.
+
+
+Getting WWDR Certificate
+==========================
+
+Certificate is available @ http://developer.apple.com/certificationauthority/AppleWWDRCA.cer
+It can be easily exported from KeyChain right to .pem


### PR DESCRIPTION
You've done a great work!
Yesterday I've tried to generate the sample pass and it failed on validation ('signpass -v pass.pkpass') and it wasn't possible to add pass to passbook (only view in add controller).

I've added WWDR support (in createSignature) as additional X509 certificate for MIME.

Actually, it is the only working example on Python in the web :)
