### PR TITLE
PKTextAlignment-Natural should be PKTextAlignmentNatural

### DIFF
--- a/passbook/models.py
+++ b/passbook/models.py
@@ -22,7 +22,7 @@ class Alignment:
     CENTER = 'PKTextAlignmentCenter'
     RIGHT = 'PKTextAlignmentRight'
     JUSTIFIED = 'PKTextAlignmentJustified'
-    NATURAL = 'PKTextAlignment-Natural'
+    NATURAL = 'PKTextAlignmentNatural'
 
 class BarcodeFormat:
     PDF417 = 'PKBarcodeFormatPDF417'


### PR DESCRIPTION
```
Invalid data error reading [PASS ID]. PKTextAlignment-Natural is not in PKTextAlignmentLeft, PKTextAlignmentCenter, PKTextAlignmentRight, PKTextAlignmentNatural
```

This pull fixed the error that prevents the pass from being added to the device.

In its current state, It is opened by quick-look but not by the device.

This fixes the problem.
