### PR TITLE
barcode now optional

### DIFF
--- a/passbook/models.py
+++ b/passbook/models.py
@@ -288,10 +288,12 @@ class Pass(object):
             'logoText': self.logoText,
             'suppressStripShine': self.suppressStripShine,
             'locations': self.locations,
-            'barcode': self.barcode.json_dict(),
             'associatedStoreIdentifiers': self.associatedStoreIdentifiers,
             self.passInformation.jsonname: self.passInformation.json_dict()
         }
+        # barcode is optional
+        if self.barcode:
+            d.update(self.barcode.json_dict())
         if self.webServiceURL:
             d.update({'webServiceURL': self.webServiceURL, 
                       'authenticationToken': self.authenticationToken}) 


### PR DESCRIPTION
Barcode is optional (Apple docs) and the comments in models.py indicate that it is optional.
However, if you do not add a barcode, then the pass can not be created.
With this patch you can leave out the barcode.
