### PR TITLE
relevantDate is now included in output

### DIFF
--- a/passbook/models.py
+++ b/passbook/models.py
@@ -292,6 +292,8 @@ class Pass(object):
             'associatedStoreIdentifiers': self.associatedStoreIdentifiers,
             self.passInformation.jsonname: self.passInformation.json_dict()
         }
+        if self.relevantDate:
+            d.update({'relevantDate': self.relevantDate})
         if self.webServiceURL:
             d.update({'webServiceURL': self.webServiceURL, 
                       'authenticationToken': self.authenticationToken}) 


### PR DESCRIPTION
relevantDate wasn't being output.
The attribute is optional. With this patch, if relevantDate is supplied, it is included in the output.
