### PR TITLE
ISSUE 30:  Add Code128 Support To BarcodeFormat

### DIFF
--- a/passbook/models.py
+++ b/passbook/models.py
@@ -267,8 +267,8 @@ class Pass(object):
         self.foregroundColor = None  # Optional. Foreground color of the pass,
         self.labelColor = None  # Optional. Color of the label text
         self.logoText = None  # Optional. Text displayed next to the logo
-        self.barcode = None  # Optional. Information specific to barcodes.  This is deprecated.
-        self.barcodes = None #Optional.  New barcodes (non legacy types)
+        self.barcode = None  # Optional. Information specific to barcodes.  This is deprecated and can only be set to original barcode formats.
+        self.barcodes = None #Optional.  All supported barcodes
         # Optional. If true, the strip image is displayed
         self.suppressStripShine = False
 

--- a/passbook/models.py
+++ b/passbook/models.py
@@ -26,13 +26,11 @@ class Alignment:
     JUSTIFIED = 'PKTextAlignmentJustified'
     NATURAL = 'PKTextAlignmentNatural'
 
-class BarcodeFormat:
+class BarcodeFormat:    
     PDF417 = 'PKBarcodeFormatPDF417'
     QR = 'PKBarcodeFormatQR'
     AZTEC = 'PKBarcodeFormatAztec'
     CODE128 = 'PKBarcodeFormatCode128'
-
-LEGACY_BARCODE_FORMATS = [BarcodeFormat.PDF417, BarcodeFormat.QR, BarcodeFormat.AZTEC]
 
 class TransitType:
     AIR = 'PKTransitTypeAir'
@@ -375,9 +373,10 @@ class Pass(object):
         }
         #barcodes have 2 fields, 'barcode' is legacy so limit it to the legacy formats, 'barcodes' supports all
         if self.barcode:
+            original_formats = [BarcodeFormat.PDF417, BarcodeFormat.QR, BarcodeFormat.AZTEC]
             legacyBarcode = self.barcode
             newBarcodes = [self.barcode.json_dict()]
-            if self.barcode.format not in LEGACY_BARCODE_FORMATS:
+            if self.barcode.format not in original_formats:
                 legacyBarcode = Barcode(self.barcode.message, BarcodeFormat.PDF417, self.barcode.altText)
             d.update({'barcodes': newBarcodes})
             d.update({'barcode': legacyBarcode})

--- a/passbook/test/test_passbook.py
+++ b/passbook/test/test_passbook.py
@@ -1,0 +1,39 @@
+"""
+Test some basic pass file generation
+"""
+
+try:
+    import json
+except ImportError:
+    import simplejson as json
+from passbook.models import Barcode, BarcodeFormat, Pass, StoreCard
+
+def create_shell_pass(barcodeFormat = BarcodeFormat.CODE128):
+    cardInfo = StoreCard()
+    stdBarcode = Barcode('test barcode', barcodeFormat, 'alternate text')
+    passfile = Pass(cardInfo, organizationName='Org Name', passTypeIdentifier='Pass Type ID', teamIdentifier='Team Identifier')
+    passfile.barcode = stdBarcode
+    return passfile
+
+def test_basic_pass():
+    passfile = create_shell_pass()
+    assert passfile.formatVersion == 1
+    assert passfile.barcode.format == BarcodeFormat.CODE128
+    
+def test_code128_pass():
+    """
+    This test is to create a pass with a new code128 format, freezes it to json, then reparses it and validates it defaults the legacy barcode correctly
+    """
+    passfile = create_shell_pass(BarcodeFormat.PDF417)
+    jsonData = created_pass = passfile._createPassJson()
+    print(jsonData)
+    thawedJson = json.loads(jsonData)
+    assert thawedJson['barcode']['format'] == BarcodeFormat.PDF417
+    assert thawedJson['barcodes'][0]['format'] == BarcodeFormat.PDF417
+
+def test_pdf_417_pass():
+    """
+    This test is to create a pass with a barcode that is valid in both past and present versions of IOS
+    """
+    passfile = create_shell_pass()
+

--- a/passbook/test/test_passbook.py
+++ b/passbook/test/test_passbook.py
@@ -24,16 +24,20 @@ def test_code128_pass():
     """
     This test is to create a pass with a new code128 format, freezes it to json, then reparses it and validates it defaults the legacy barcode correctly
     """
-    passfile = create_shell_pass(BarcodeFormat.PDF417)
+    passfile = create_shell_pass()
     jsonData = created_pass = passfile._createPassJson()
-    print(jsonData)
     thawedJson = json.loads(jsonData)
     assert thawedJson['barcode']['format'] == BarcodeFormat.PDF417
-    assert thawedJson['barcodes'][0]['format'] == BarcodeFormat.PDF417
+    assert thawedJson['barcodes'][0]['format'] == BarcodeFormat.CODE128
 
 def test_pdf_417_pass():
     """
     This test is to create a pass with a barcode that is valid in both past and present versions of IOS
     """
+    passfile = create_shell_pass(BarcodeFormat.PDF417)
+    jsonData = created_pass = passfile._createPassJson()
+    thawedJson = json.loads(jsonData)
+    assert thawedJson['barcode']['format'] == BarcodeFormat.PDF417
+    assert thawedJson['barcodes'][0]['format'] == BarcodeFormat.PDF417
     passfile = create_shell_pass()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 M2Crypto>=0.21.1
+pytest


### PR DESCRIPTION
Here is a minimalist patch to address https://github.com/devartis/passbook/issues/30.  It does 2 things:
1)  Starts setting the 'barcodes' field that has been added as of ios9
2)  Adds the CODE128 type as a valid BarcodeFormat.  Note that if you set the barcode format to CODE128 this code sets the legacy field to the default PDF417

I also added a couple of simple unit tests.  Could use some more of those.

Possible Enhancements which would be slightly more invasive:
a) Would be easy to allow the user to over-ride the legacy default if someone needs that.
b) The apple wallet api supports a list of barcodes, but this code always creates a list of 1