### PR TITLE
Test signature and creation of pkpass file.

### DIFF
--- a/passbook/test/certificates/.gitignore
+++ b/passbook/test/certificates/.gitignore
@@ -1,0 +1,2 @@
+password.txt
+*.pem


### PR DESCRIPTION
These tests can only run on a developer's computer and not on the public continuous integration system (Travis CI) because they rely on personal Apple Developer certificates and private key (which must be kept secret). It would not be wise to add theses files to git.

In order to run these tests you must place the required files manually. See the tests about the location and names of the files.

Test coverage increases from 65% to 75% with these tests.