### PR TITLE
Fix currency field.

### DIFF
--- a/passbook/models.py
+++ b/passbook/models.py
@@ -66,7 +66,7 @@ class DateField(Field):
 
     def __init__(self, key, value, label='', dateStyle=DateStyle.SHORT,
                  timeStyle=DateStyle.SHORT, ignoresTimeZone=False):
-        super(DateField, self).__init__(key, value, label)
+        super().__init__(key, value, label)
         self.dateStyle = dateStyle  # Style of date to display
         self.timeStyle = timeStyle  # Style of time to display
         self.isRelative = False  # If true, the labels value is displayed as a relative date
@@ -80,7 +80,7 @@ class DateField(Field):
 class NumberField(Field):
 
     def __init__(self, key, value, label=''):
-        super(NumberField, self).__init__(key, value, label)
+        super().__init__(key, value, label)
         self.numberStyle = NumberStyle.DECIMAL  # Style of date to display
 
     def json_dict(self):
@@ -90,7 +90,7 @@ class NumberField(Field):
 class CurrencyField(Field):
 
     def __init__(self, key, value, label='', currencyCode=''):
-        super(CurrencyField, self).__init__(key, value, label)
+        super().__init__(key, value, label)
         self.currencyCode = currencyCode  # ISO 4217 currency code
 
     def json_dict(self):
@@ -194,12 +194,12 @@ class PassInformation(object):
 class BoardingPass(PassInformation):
 
     def __init__(self, transitType=TransitType.AIR):
-        super(BoardingPass, self).__init__()
+        super().__init__()
         self.transitType = transitType
         self.jsonname = 'boardingPass'
 
     def json_dict(self):
-        d = super(BoardingPass, self).json_dict()
+        d = super().json_dict()
         d.update({'transitType': self.transitType})
         return d
 
@@ -207,28 +207,28 @@ class BoardingPass(PassInformation):
 class Coupon(PassInformation):
 
     def __init__(self):
-        super(Coupon, self).__init__()
+        super().__init__()
         self.jsonname = 'coupon'
 
 
 class EventTicket(PassInformation):
 
     def __init__(self):
-        super(EventTicket, self).__init__()
+        super().__init__()
         self.jsonname = 'eventTicket'
 
 
 class Generic(PassInformation):
 
     def __init__(self):
-        super(Generic, self).__init__()
+        super().__init__()
         self.jsonname = 'generic'
 
 
 class StoreCard(PassInformation):
 
     def __init__(self):
-        super(StoreCard, self).__init__()
+        super().__init__()
         self.jsonname = 'storeCard'
 
 

--- a/passbook/models.py
+++ b/passbook/models.py
@@ -87,7 +87,7 @@ class NumberField(Field):
         return self.__dict__
 
 
-class CurrencyField(NumberField):
+class CurrencyField(Field):
 
     def __init__(self, key, value, label='', currencyCode=''):
         super(CurrencyField, self).__init__(key, value, label)

--- a/passbook/test/test_passbook.py
+++ b/passbook/test/test_passbook.py
@@ -7,7 +7,7 @@ from M2Crypto import SMIME
 from M2Crypto import X509
 from path import Path
 
-from passbook.models import Barcode, BarcodeFormat, Pass, StoreCard
+from passbook.models import Barcode, BarcodeFormat, CurrencyField, Pass, StoreCard
 
 cwd = Path(__file__).parent
 
@@ -198,3 +198,19 @@ def test_passbook_creation():
     passfile = create_shell_pass()
     passfile.addFile('icon.png', open(cwd / 'static' / 'white_square.png', 'rb'))
     passfile.create(certificate, key, wwdr_certificate, password)
+
+
+def test_currency_field_has_no_numberstyle():
+    balance_field = CurrencyField(
+        'balance',
+        float(22.00),
+        'test label',
+        'USD',
+    )
+
+    passfile = create_shell_pass()
+    passfile.passInformation.headerFields.append(balance_field)
+
+    pass_json = passfile.json_dict()
+    assert 'currencyCode' in pass_json['storeCard']['headerFields'][0]
+    assert 'numberStyle' not in pass_json['storeCard']['headerFields'][0]


### PR DESCRIPTION
A field containing a numeric value can have an optional number style key. The key has to be either "currencyCode" or "numberStyle".

See the documentation about "Number Style Keys" available at https://developer.apple.com/library/archive/documentation/UserExperience/Reference/PassKit_Bundle/Chapters/FieldDictionary.html#//apple_ref/doc/uid/TP40012026-CH4-SW7

Closes issue #38.

This has been inspired by https://github.com/devartis/passbook/pull/37/files and https://github.com/ofw/wallet-py3k/commit/f5aff37dc80380ee1ea96c7af5e84615ae9f79f0

