### PR TITLE
Small fix to the LICENSE 

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,3 +1,5 @@
+The MIT License (MIT)
+
 Copyright (c) 2012 devartis
 
 Permission is hereby granted, free of charge, to any


### PR DESCRIPTION
Suggested small fix to the license file so that pypi.org correctly picks the license and automatic license scanners work as expected.

This fixes issue #56 --- No need to remove the copyright notice

NB: I have few experience posting packages to pypi.org myself. So I'm doing this fix by similarity to other projects. 